### PR TITLE
Remove duplicate 'default export'

### DIFF
--- a/src/js/base/MotionBank.js
+++ b/src/js/base/MotionBank.js
@@ -4,7 +4,7 @@
  * MotionBank class
  * @access public
  */
-export default class MotionBank {
+export class MotionBank {
   /**
    * constructor
    * @access public


### PR DESCRIPTION
```
$ node --version
v8.9.4
```

```
$ npm run build

> dh3dlib@0.3.0 build ~/work/DH3DLibrary
> gulp build

[15:45:57] Using gulpfile ~/work/DH3DLibrary/gulpfile.js
[15:45:57] Starting 'webpack'...


[15:45:57] Finished 'webpack' after 360 ms
[15:45:57] Starting 'build'...
[15:45:57] Finished 'build' after 45 μs
[15:46:10] Version: webpack 1.15.0
  Asset    Size  Chunks             Chunk Names
dh3d.js  563 kB       0  [emitted]  main

ERROR in ./src/js/base/MotionBank.js
Module build failed: SyntaxError: Only one default export allowed per module. (96:0)

  94 |
  95 | // for singleton
> 96 | export default new MotionBank()
     | ^
  97 |
  98 |

 @ ./src/js/main.js 187:18-46

```